### PR TITLE
Only run Librarian when a Cheffile exists in the Vagrant root

### DIFF
--- a/lib/vagrant-librarian-chef/action/librarian_chef.rb
+++ b/lib/vagrant-librarian-chef/action/librarian_chef.rb
@@ -10,11 +10,14 @@ module VagrantPlugins
         end
 
         def call(env)
-          env[:ui].info "Installing Chef cookbooks with Librarian-Chef..."
-          environment = Librarian::Chef::Environment.new
-          Librarian::Action::Ensure.new(environment).run
-          Librarian::Action::Resolve.new(environment).run
-          Librarian::Action::Install.new(environment).run
+          # look for a Cheffile in the Vagrant root_path
+          if FileTest.exist?(env[:root_path] + "Cheffile")
+            env[:ui].info "Installing Chef cookbooks with Librarian-Chef..."
+            environment = Librarian::Chef::Environment.new
+            Librarian::Action::Ensure.new(environment).run
+            Librarian::Action::Resolve.new(environment).run
+            Librarian::Action::Install.new(environment).run
+          end
           @app.call(env)
         end
       end


### PR DESCRIPTION
This should fix jimmycuadra/vagrant-librarian-chef#1.

I'm not sure if it's better to use `env.root_path` or `env[:cwd]` though.
