### PR TITLE
Fixes librarian's :project_path so vagrant commands can be run in subdirs of :root_path

### DIFF
--- a/lib/vagrant-librarian-chef/action/librarian_chef.rb
+++ b/lib/vagrant-librarian-chef/action/librarian_chef.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
           if FileTest.exist? File.join(env[:root_path], config.cheffile_path)
             env[:ui].info "Installing Chef cookbooks with Librarian-Chef..."
             environment = Librarian::Chef::Environment.new({
-              :project_path => config.cheffile_dir
+              :project_path => File.join(env[:root_path], config.cheffile_dir)
             })
             Librarian::Action::Ensure.new(environment).run
             Librarian::Action::Resolve.new(environment).run


### PR DESCRIPTION
This was a big from my previous pull request, and vagrant errors out if you  are running commands at a deeper level than the topmost.
