### PR TITLE
Use '.' as the default for `cheffile_dir`.

### DIFF
--- a/lib/vagrant-librarian-chef/config.rb
+++ b/lib/vagrant-librarian-chef/config.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
       end
 
       def finalize!
-        @cheffile_dir = nil if @cheffile_dir == UNSET_VALUE
+        @cheffile_dir = "." if @cheffile_dir == UNSET_VALUE
       end
 
       def cheffile_path


### PR DESCRIPTION
The existing default (`nil`) causes the following failure on `Vagrantfiles` that do not specify `cheffile_dir`:

```
$ vagrant -v
Vagrant version 1.1.5
$ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
[default] Importing base box 'opscode-ubuntu-12.04'...
[0K[default] Matching MAC address for NAT networking...
[default] Setting the name of the VM...
[default] Clearing any previously set forwarded ports...
[default] Installing Chef cookbooks with Librarian-Chef...
[default] Destroying VM and associated drives...
/Users/wcmaier/.vagrant.d/gems/gems/vagrant-librarian-chef-0.1.1/lib/vagrant-librarian-chef/action/librarian_chef.rb:20:in `join': can't convert nil into String (TypeError)
[...]
$ cat Vagrantfile 
#!/usr/bin/env ruby

Vagrant.configure('2') do |config|
  config.vm.hostname = 'ceilometer'
  config.vm.box = ENV['VAGRANT_BOX'] || 'opscode-ubuntu-12.04'
  config.vm.box_url = ENV['VAGRANT_BOX_URL'] || "https://opscode-vm.s3.amazonaws.com/vagrant/boxes/#{config.vm.box}.box"

  config.vm.provision :chef_solo do |chef|
    chef.run_list = [
      'recipe[ceilometer::default]'
    ]
  end
end
$ cat Cheffile
site 'http://community.opscode.com/api/v1'

cookbook 'ceilometer',
         :path => './'
```
