### PR TITLE
allow config.cheffile_dir to contain an absolute path

### DIFF
--- a/lib/vagrant-librarian-chef/action/librarian_chef.rb
+++ b/lib/vagrant-librarian-chef/action/librarian_chef.rb
@@ -13,17 +13,29 @@ module VagrantPlugins
 
         def call(env)
           config = env[:global_config].librarian_chef
-          # look for a Cheffile in the configured cheffile_dir
-          if FileTest.exist? File.join(env[:root_path], config.cheffile_path)
+
+          project_path = get_project_path(env, config)
+          if project_path
             env[:ui].info "Installing Chef cookbooks with Librarian-Chef..."
             environment = Librarian::Chef::Environment.new({
-              :project_path => File.join(env[:root_path], config.cheffile_dir)
+              :project_path => project_path
             })
             Librarian::Action::Ensure.new(environment).run
             Librarian::Action::Resolve.new(environment).run
             Librarian::Action::Install.new(environment).run
+          else
+            env[:ui].info "Couldn't find Cheffile at #{config.cheffile_path}."
           end
           @app.call(env)
+        end
+
+        def get_project_path(env, config)
+          # look for a Cheffile in the configured cheffile_dir
+          if FileTest.exist? config.cheffile_path
+            return config.cheffile_dir
+          elsif FileTest.exist? File.join(env[:root_path], config.cheffile_path)
+            return File.join(env[:root_path], config.cheffile_dir)
+          end
         end
       end
     end


### PR DESCRIPTION
The Cheffile had to be located in a subdirectory of the vagrant dir before,
this gets rid of that requirement transparently. Also added an INFO message in
case the Cheffile is not found.
