### PR TITLE
compatibility with Vagrant 1.5 config

### DIFF
--- a/lib/vagrant-librarian-chef/action/librarian_chef.rb
+++ b/lib/vagrant-librarian-chef/action/librarian_chef.rb
@@ -8,11 +8,11 @@ module VagrantPlugins
         def initialize(app, env)
           @app = app
           # Config#finalize! SHOULD be called automatically
-          env[:global_config].librarian_chef.finalize!
+          env[:machine].config.librarian_chef.finalize!
         end
 
         def call(env)
-          config = env[:global_config].librarian_chef
+          config = env[:machine].config.librarian_chef
 
           project_path = get_project_path(env, config)
           if project_path


### PR DESCRIPTION
Vagrant 1.5 doesn't seem to support `env[:global_config]` to retrieve your config however you can get this via `env[:machine].config` instead.

``` shell
$ vagrant up
Bringing machine 'default' up with 'vmware_fusion' provider...
==> default: Cloning VMware VM: 'chef/centos-6.5'. This can take some time...
==> default: Checking if box 'chef/centos-6.5' is up to date...
==> default: Verifying vmnet devices are healthy...
==> default: Deleting the VM...
==> default: Running cleanup tasks for 'chef_solo' provisioner...
/Users/rjocoleman/.vagrant.d/gems/gems/vagrant-librarian-chef-0.1.4/lib/vagrant-librarian-chef/action/librarian_chef.rb:11:in `initialize': undefined method `librarian_chef' for nil:NilClass (NoMethodError)
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:90:in `new'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:90:in `finalize_action'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:20:in `block in initialize'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:20:in `map'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:20:in `initialize'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/builder.rb:170:in `new'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/builder.rb:170:in `to_app'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/builtin/call.rb:50:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Users/rjocoleman/.vagrant.d/gems/gems/vagrant-vmware-fusion-2.3.4/lib/vagrant-vmware-fusion/action_farm.rb:80:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Users/rjocoleman/.vagrant.d/gems/gems/vagrant-vmware-fusion-2.3.4/lib/vagrant-vmware-fusion/action_farm.rb:1018:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/builder.rb:116:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/runner.rb:69:in `block in run'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/util/busy.rb:19:in `busy'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/runner.rb:69:in `run'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/builtin/call.rb:51:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/builtin/box_check_outdated.rb:60:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Users/rjocoleman/.vagrant.d/gems/gems/vagrant-vmware-fusion-2.3.4/lib/vagrant-vmware-fusion/action_farm.rb:1232:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Users/rjocoleman/.vagrant.d/gems/gems/vagrant-vmware-fusion-2.3.4/lib/vagrant-vmware-fusion/action_farm.rb:282:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Users/rjocoleman/.vagrant.d/gems/gems/vagrant-vmware-fusion-2.3.4/lib/vagrant-vmware-fusion/action_farm.rb:152:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Users/rjocoleman/.vagrant.d/gems/gems/vagrant-vmware-fusion-2.3.4/lib/vagrant-vmware-fusion/action_farm.rb:1097:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Users/rjocoleman/.vagrant.d/gems/gems/vagrant-vmware-fusion-2.3.4/lib/vagrant-vmware-fusion/action_farm.rb:472:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/builtin/handle_box.rb:56:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/builder.rb:116:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/runner.rb:69:in `block in run'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/util/busy.rb:19:in `busy'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/runner.rb:69:in `run'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/builtin/call.rb:51:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Users/rjocoleman/.vagrant.d/gems/gems/vagrant-vmware-fusion-2.3.4/lib/vagrant-vmware-fusion/action_farm.rb:1232:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/builtin/lock.rb:42:in `block in call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/builtin/lock.rb:27:in `open'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/builtin/lock.rb:27:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Users/rjocoleman/.vagrant.d/gems/gems/vagrant-vmware-fusion-2.3.4/lib/vagrant-vmware-fusion/action_farm.rb:108:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Users/rjocoleman/.vagrant.d/gems/gems/vagrant-vmware-fusion-2.3.4/lib/vagrant-vmware-fusion/action_farm.rb:282:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/builtin/config_validate.rb:25:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Users/rjocoleman/.vagrant.d/gems/gems/vagrant-vmware-fusion-2.3.4/lib/vagrant-vmware-fusion/action_farm.rb:169:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/warden.rb:34:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/builder.rb:116:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/runner.rb:69:in `block in run'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/util/busy.rb:19:in `busy'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/action/runner.rb:69:in `run'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/machine.rb:157:in `action'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/batch_action.rb:72:in `block (2 levels) in run'
```
