### PR TITLE
gemspec: bump librarian-chef

### DIFF
--- a/vagrant-librarian-chef.gemspec
+++ b/vagrant-librarian-chef.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "librarian-chef"
+  spec.add_runtime_dependency "librarian-chef", "0.0.3"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
Looks like there are SSL errors on 0.0.4, let's force to 0.0.3 to make sure people don't run into them for now. 0.0.4 was released today: https://github.com/applicationsonline/librarian-chef

:heart: if you release a new version with this.
