### PR TITLE
Ensure Vagrant can properly merge multiple configurations

### DIFF
--- a/lib/vagrant-librarian-chef/config.rb
+++ b/lib/vagrant-librarian-chef/config.rb
@@ -11,11 +11,12 @@ module VagrantPlugins
 
       def initialize
         @cheffile_dir = UNSET_VALUE
-        @enabled      = true
+        @enabled      = UNSET_VALUE
       end
 
       def finalize!
         @cheffile_dir = "." if @cheffile_dir == UNSET_VALUE
+        @enabled = true if @enabled == UNSET_VALUE
       end
 
       def cheffile_path


### PR DESCRIPTION
In my humble opinion it would be better to use the canonical way for defining configuration variables.

According to [Vagrant docs](http://docs.vagrantup.com/v2/plugins/configuration.html), `UNSET_VALUE` is used  for ensuring correct Vagrantfile merge-logic.
